### PR TITLE
Support optional env_file input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,9 @@ inputs:
   version:
     description: Version to use; dev/beta/stable or a specific version number
     required: false
+  env_file:
+    description: Possible path to environment file to use
+    required: false
 
 runs:
   using: "composite"
@@ -101,10 +104,15 @@ runs:
           --entrypoint "" \
           "homeassistant/home-assistant:${{ steps.version.outputs.version }}" \
             python -m homeassistant --version
-
+        if [[ -f "${{ inputs.env_file }}" ]]; then
+          env_file_arg="--env-file ${{ inputs.env_file }}"
+        else
+          env_file_arg=""
+        fi
         docker run --rm \
           --entrypoint "" \
           -v $(pwd):/github/workspace \
+          $env_file_arg \
           --workdir /github/workspace \
           "homeassistant/home-assistant:${{ steps.version.outputs.version }}" \
             python -m homeassistant \

--- a/action.yaml
+++ b/action.yaml
@@ -104,10 +104,9 @@ runs:
           --entrypoint "" \
           "homeassistant/home-assistant:${{ steps.version.outputs.version }}" \
             python -m homeassistant --version
+        env_file_arg=""
         if [[ -f "${{ inputs.env_file }}" ]]; then
           env_file_arg="--env-file ${{ inputs.env_file }}"
-        else
-          env_file_arg=""
         fi
         docker run --rm \
           --entrypoint "" \


### PR DESCRIPTION
Closes #43.

Via a file `env_file` as optional input of the action where you can give up an `.env` file, then it will add `--env-file` to the docker check command. This will allow you to use `!env_var` inside of your home assistant config and have an env stub where you store secrets/variables.