### PR TITLE
Add repo to real-world uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ you with some real-world uses of this GitHub Action.
 - [Metbril's :sunglasses: Home Assistant Configuration](https://github.com/metbril/home-assistant-config)
 - [ntilley905's Home Assistant Configuration](https://github.com/ntilley905/hass)
 - [robbrad's Home Assistant Configuration](https://github.com/robbrad/HA-Config)
+- [Pinkywafer's Home Assistant Configuration](https://github.com/pinkywafer/Home-Assistant_Config)
 
 Are you using this GitHub Action? Feel free to open up a PR to add your
 configuration to this list 😍


### PR DESCRIPTION
Adds my repo to the real world uses.

I'm also using an extra job in my workflow to get the version number that I currently have installed (from the .HA_VERSION file) and add that version to the matrix, so testing against stable, dev, beta and whatever version I have installed at the time.

Thanks 👍